### PR TITLE
add col format footprint cutter

### DIFF
--- a/scripts/check_footprint.py
+++ b/scripts/check_footprint.py
@@ -206,8 +206,8 @@ def main(argv=None):
     if params['verbose']:
         print(f'Writing objects in footprint to {params["output_path"]}')
     cols = []
-    for key in t.keys():
-        cols.append(fits.Column(name=key, array=t[key], format='E'))
+    for col_ind,key in enumerate(t.keys()):
+        cols.append(fits.Column(name=key, array=t[key], format=dat_in_footprint.columns[col_ind].format))
     cs_cat.write_fits_BinTable_file(cols, params["output_path"])
 
     # Create plots


### PR DESCRIPTION
Keep format of original fits file for columns, forcing to 'E' (single precision) can lead to problems, e.g. matching RA, DEC (the Table object has lost the fits file format letter so need to look it up in dat_in_footprint)